### PR TITLE
Blue section

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -78,6 +78,7 @@ body {
   font-family: var(--body-font-family);
   font-size: var(--body-font-size-m);
   line-height: 1.6;
+  font-size: .875rem;
 }
 
 body.appear {
@@ -249,9 +250,75 @@ main > .section:first-of-type {
 }
 
 /* section metadata */
-main .section.light,
+/* main .section.light,
 main .section.highlight {
   background-color: var(--light-color);
   margin: 0;
   padding: 40px 0;
+} */
+
+.section {
+  &.highlight {
+    padding: 3em 15px;
+    margin-bottom: 1.5em;
+    text-align: center;
+
+    & .default-content-wrapper {
+      margin: 0 auto;
+      max-width: 1400px;
+      padding-inline: 0;
+
+      > *:last-child {
+        margin-bottom: 0;
+      }
+    }
+
+    h2 {
+      font-size: 1.625rem;
+      font-style: italic;
+      margin: 0;
+    }
+
+    p {
+      font-size: 0.875rem;
+      margin: 0 0 1.5em;
+    }
+
+    a {
+      text-decoration: underline;
+    }
+
+    ul {
+      padding-left: 0;
+      margin: 0 0 1.5em;
+      list-style-position: inside;
+    }
+
+    picture {
+      display: block;
+      text-align: center;
+    }
+
+    @media (min-width: 48em) {
+      margin-bottom: 3em;
+      padding-inline: 20px;
+    }
+
+    @media (min-width: 64em) {
+      text-align: left;
+    }
+
+    &.background-blue {
+      background: #388ce1;
+      color: rgb(255 255 255 / 80%);
+
+      h2 {
+        color: #fff;
+      }
+
+      a {
+        color: #fff;
+      }
+    }
+  }
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -80,14 +80,6 @@ footer .footer {
       text-align: center;
     }
 
-    @media (min-width: 48em) {
-      margin-bottom: 3em;
-      padding-inline: 20px;
-    }
-
-    @media (min-width: 64em) {
-      text-align: left;
-    }
 
     &.background-blue {
       background: #388ce1;
@@ -100,6 +92,15 @@ footer .footer {
       a {
         color: #fff;
       }
+    }
+
+    @media (width >= 48em) {
+      margin-bottom: 3em;
+      padding-inline: 20px;
+    }
+
+    @media (width >= 64em) {
+      text-align: left;
     }
   }
 }


### PR DESCRIPTION
Styles for blue background section using free form text. Fonts currently missing and tokens to be retrofitted once established. Some considerations added for lists and pictures in case they were added by an editor (but will come down to training to advise against this). Minor adjustments made to improve margins and padding in comparison to live component.

I have added some test content to Sharepoint to demonstrate what I'd used for this section locally: https://dartgrp.sharepoint.com/:w:/r/sites/Adobe-EDS/_layouts/15/Doc.aspx?sourcedoc=%7B68F79EE0-B93C-4159-8F85-003D86CF8C98%7D&file=blue-section.docx&action=default&mobileredirect=true

However, I can't get Sidekick working with Sharepoint yet to create the test URLs, so any help/guidance on this would be appreciated.

URL for testing:

- https://blue-section--eds--leilahbirchall-jet2.aem.page/blue-section