### PR TITLE
feat: Section layout

### DIFF
--- a/blocks/image/image.css
+++ b/blocks/image/image.css
@@ -1,0 +1,6 @@
+.image.block {
+    & img {
+        max-width: 100%;
+        height: auto;
+    }
+}

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -11,6 +11,8 @@ import {
   loadSection,
   loadSections,
   loadCSS,
+  readBlockConfig,
+  toCamelCase
 } from './aem.js';
 
 /**
@@ -54,6 +56,88 @@ function buildAutoBlocks(main) {
 }
 
 /**
+ * Reads the 'Layout' key from section metadata, 
+ * specifically with the 'columns' value.
+ * 
+ * This will look for a table inside of the 'columns' 
+ * value, specifing the widths to display the columns at.
+ * Once found, these are converted into --left and --right 
+ * CSS variables to apply to the section element for use in
+ * the {@link buildLayoutContainer} function.
+ * 
+ * @param {Element} main The container element
+ */
+function readLayoutMeta(main) {
+  const checkColumnExists = (column, name) => 
+    column && column.innerHTML.toLowerCase().includes(name);
+
+  main.querySelectorAll(':scope > div').forEach((section) => {
+    const sectionMeta = section.querySelector('div.section-metadata');
+
+    if (sectionMeta) {
+      const key = 'layout';
+      const value = 'columns';
+      const blockConfig = readBlockConfig(sectionMeta);
+
+      if (blockConfig.hasOwnProperty(key) && blockConfig[key] === value) {
+        sectionMeta.querySelectorAll(':scope > div').forEach((row) => {
+          if (row.children) {
+            const cols = [...row.children];
+            const equalToLayout = checkColumnExists(cols[0], key);
+            const equalToColumns = checkColumnExists(cols[1], value);
+
+            if (equalToLayout && equalToColumns) {
+              const col = cols[1];
+
+              if (col.querySelector('table')) {
+                const table = col.querySelector('table');
+                const tableData = table.querySelectorAll('td');
+                [...tableData].map((value, index) => {
+                  const varName = `--${index === 0 ? 'left' : 'right'}`;
+                  section.style.setProperty(varName, value.innerHTML);
+                });
+                section.dataset[toCamelCase(key)] = blockConfig[key];
+              }
+            }
+          }
+        });
+      }
+    }
+  });
+}
+
+/**
+ * Builds two column grid, dependent 
+ * on 'Layout' section metadata.
+ * 
+ * @param {Element} main The container element
+ */
+function buildLayoutContainer(main) {
+  const createDiv = (content) => {
+    const div = document.createElement('div');
+    div.classList.add('grid-column');
+    div.append(content);
+    return div;
+  }
+
+  main.querySelectorAll(':scope > .section[data-layout="columns"]').forEach((section) => {
+    const wrapper = document.createElement('div');
+    wrapper.classList.add('default-content-wrapper');
+
+    if (section.children.length === 2) {
+      const leftContent = section.children[0];
+      const rightContent = section.children[1];
+
+      const leftDiv = createDiv(leftContent);
+      const rightDiv = createDiv(rightContent);
+
+      wrapper.append(leftDiv, rightDiv);
+      section.append(wrapper);
+    }
+  });
+}
+
+/**
  * Decorates the main element.
  * @param {Element} main The main element
  */
@@ -63,8 +147,10 @@ export function decorateMain(main) {
   decorateButtons(main);
   decorateIcons(main);
   buildAutoBlocks(main);
+  readLayoutMeta(main);
   decorateSections(main);
   decorateBlocks(main);
+  buildLayoutContainer(main);
 }
 
 /**

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -94,8 +94,11 @@ function readLayoutMeta(main) {
                 const table = col.querySelector('table');
                 const tableData = table.querySelectorAll('td');
                 [...tableData].forEach((value, index) => {
-                  const varName = `--${index === 0 ? 'left' : 'right'}`;
-                  section.style.setProperty(varName, value.innerHTML);
+                  const varName = `--${index === 0 ? 'layout-column-left' : 'layout-column-right'}`;
+                  const width = value.innerHTML;
+                  if (width.endsWith('%')) {
+                    section.style.setProperty(varName, value.innerHTML);
+                  } 
                 });
                 section.dataset[toCamelCase(configKey)] = sectionMetaConfig[configKey];
               }
@@ -116,7 +119,7 @@ function readLayoutMeta(main) {
 function buildLayoutContainer(main) {
   const createDiv = (content) => {
     const div = document.createElement('div');
-    div.classList.add('grid-column');
+    div.classList.add('layout-column');
     div.append(content);
     return div;
   };

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -12,7 +12,7 @@ import {
   loadSections,
   loadCSS,
   readBlockConfig,
-  toCamelCase
+  toCamelCase,
 } from './aem.js';
 
 /**
@@ -56,35 +56,36 @@ function buildAutoBlocks(main) {
 }
 
 /**
- * Reads the 'Layout' key from section metadata, 
+ * Reads the 'Layout' key from section metadata,
  * specifically with the 'columns' value.
- * 
- * This will look for a table inside of the 'columns' 
+ *
+ * This will look for a table inside of the 'columns'
  * value, specifing the widths to display the columns at.
- * Once found, these are converted into --left and --right 
+ * Once found, these are converted into --left and --right
  * CSS variables to apply to the section element for use in
  * the {@link buildLayoutContainer} function.
- * 
+ *
  * @param {Element} main The container element
  */
 function readLayoutMeta(main) {
-  const checkColumnExists = (column, name) => 
-    column && column.innerHTML.toLowerCase().includes(name);
+  const checkColExists = (column, name) => column && column.innerHTML.toLowerCase().includes(name);
 
   main.querySelectorAll(':scope > div').forEach((section) => {
     const sectionMeta = section.querySelector('div.section-metadata');
 
     if (sectionMeta) {
-      const key = 'layout';
-      const value = 'columns';
-      const blockConfig = readBlockConfig(sectionMeta);
+      const sectionMetaConfig = readBlockConfig(sectionMeta);
+      const configKey = 'layout';
+      const configValue = 'columns';
+      const hasLayoutConfig = Object.prototype.hasOwnProperty.call(sectionMetaConfig, configKey);
+      const hasColumnsConfig = sectionMetaConfig[configKey] === configValue;
 
-      if (blockConfig.hasOwnProperty(key) && blockConfig[key] === value) {
+      if (hasLayoutConfig && hasColumnsConfig) {
         sectionMeta.querySelectorAll(':scope > div').forEach((row) => {
           if (row.children) {
             const cols = [...row.children];
-            const equalToLayout = checkColumnExists(cols[0], key);
-            const equalToColumns = checkColumnExists(cols[1], value);
+            const equalToLayout = checkColExists(cols[0], configKey);
+            const equalToColumns = checkColExists(cols[1], configValue);
 
             if (equalToLayout && equalToColumns) {
               const col = cols[1];
@@ -92,11 +93,11 @@ function readLayoutMeta(main) {
               if (col.querySelector('table')) {
                 const table = col.querySelector('table');
                 const tableData = table.querySelectorAll('td');
-                [...tableData].map((value, index) => {
+                [...tableData].forEach((value, index) => {
                   const varName = `--${index === 0 ? 'left' : 'right'}`;
                   section.style.setProperty(varName, value.innerHTML);
                 });
-                section.dataset[toCamelCase(key)] = blockConfig[key];
+                section.dataset[toCamelCase(configKey)] = sectionMetaConfig[configKey];
               }
             }
           }
@@ -107,9 +108,9 @@ function readLayoutMeta(main) {
 }
 
 /**
- * Builds two column grid, dependent 
+ * Builds two column grid, dependent
  * on 'Layout' section metadata.
- * 
+ *
  * @param {Element} main The container element
  */
 function buildLayoutContainer(main) {
@@ -118,7 +119,7 @@ function buildLayoutContainer(main) {
     div.classList.add('grid-column');
     div.append(content);
     return div;
-  }
+  };
 
   main.querySelectorAll(':scope > .section[data-layout="columns"]').forEach((section) => {
     const wrapper = document.createElement('div');

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -98,7 +98,7 @@ function readLayoutMeta(main) {
                   const width = value.innerHTML;
                   if (width.endsWith('%')) {
                     section.style.setProperty(varName, value.innerHTML);
-                  } 
+                  }
                 });
                 section.dataset[toCamelCase(configKey)] = sectionMetaConfig[configKey];
               }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -112,12 +112,12 @@ footer .footer {
       flex-direction: column;
       gap: 20px;
 
-      & .grid-column:first-of-type {
-        width: var(--left);
+      & .layout-column:first-of-type {
+        width: var(--layout-column-left);
       }
 
-      & .grid-column:last-of-type {
-        width: var(--right);
+      & .layout-column:last-of-type {
+        width: var(--layout-column-right);
       }
     }
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -38,6 +38,11 @@ footer .footer {
   }
 }
 
+.default-content-wrapper {
+  margin: 0 auto;
+  max-width: 1400px;
+}
+
 .section {
   &.highlight {
     padding: 3em 15px;
@@ -45,8 +50,6 @@ footer .footer {
     text-align: center;
 
     & .default-content-wrapper {
-      margin: 0 auto;
-      max-width: 1400px;
       padding-inline: 0;
 
       > *:last-child {
@@ -80,7 +83,6 @@ footer .footer {
       text-align: center;
     }
 
-
     &.background-blue {
       background: #388ce1;
       color: rgb(255 255 255 / 80%);
@@ -101,6 +103,28 @@ footer .footer {
 
     @media (width >= 64em) {
       text-align: left;
+    }
+  }
+
+  &[data-layout="columns"] {
+    > .default-content-wrapper {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+
+      & .grid-column:first-of-type {
+        width: var(--left);
+      }
+
+      & .grid-column:last-of-type {
+        width: var(--right);
+      }
+    }
+
+    @media (width >= 48em) {
+      > .default-content-wrapper {
+        flex-direction: row;
+      }
     }
   }
 }


### PR DESCRIPTION
Functions to read and convert 'Layout' section metadata into columns that can have defined widths in the content documents. This has been structured in a simple format to read if the layout should display in columns, then using a table inside of this column an editor can dictate what the widths should show (using percentages). This can work for a set of free flow text (FFT) and 1 block, or 2 blocks, but not 2 sets of FFT as there isn't a way to separate the text whilst still recognising it in the same section - unless I'm misunderstanding something here! However, perhaps we could add something in that would be recognised as a separator to handle this.
 
![Screenshot 2025-01-22 at 16 59 42](https://github.com/user-attachments/assets/301075c7-1847-4774-b544-0bea7e708207)

The `readLayoutMeta` function will look for the table and once found converts the values into `--layout-column-left` and `--layout-left-right` CSS variables and applies them to the section element. Using the `buildLayoutContainer` function, a left and right div are created inside this section, along with a wrapper div, to place the content inside of for styling. Using the `data-layout="columns"` attribute, flex styling is then applied taking the CSS variables that have been set.

![Screenshot 2025-01-22 at 17 32 37](https://github.com/user-attachments/assets/963c65b0-c4d0-4cfb-89e8-58e2f10a5fc7)

Image block set up for testing purposes with very minimal styles applied. Demo content added to the drafts folder again in Sharepoint:

Test URLs:
- https://section-layout--eds--leilahbirchall-jet2.aem.live/layout
